### PR TITLE
Remove navigator autocomplete for discord username input

### DIFF
--- a/src/routes/dashboard/[id]/users/+page.svelte
+++ b/src/routes/dashboard/[id]/users/+page.svelte
@@ -104,7 +104,7 @@
 						<p>Discord username : </p>
 					</div>
 					<input
-						class="input {inputDiscordError? 'input-error' : ''} autocomplete p-4 pb-2 pt-2 w-full"
+						class="input {inputDiscordError? 'input-error' : ''} p-4 pb-2 pt-2 w-full"
 						type="search"
 						name="discord-user"
 						bind:value={inputDiscord}


### PR DESCRIPTION
When adding a student, there are two autocompletes that appear on discord username input : the one from svelte and the one from the browser. The one from the browser is useless because svelte already does it. Of course I keep the browser autocomplete for input 42 intra usernames because it does not have the svelte autocomplete.

![image](https://github.com/user-attachments/assets/edd204ca-a067-4bc8-8593-b117e4cbed40)
